### PR TITLE
fix(comment): コメントパターン30のとき、コメント文が出力されない不具合を修正

### DIFF
--- a/lib/receiptisan/model/receipt_computer/master/treatment/comment.rb
+++ b/lib/receiptisan/model/receipt_computer/master/treatment/comment.rb
@@ -37,8 +37,6 @@ module Receiptisan
               unless pattern.requires_embdding?
                 return \
                   case pattern.code
-                  when Pattern::APPEND_FREE
-                    appended_content
                   when Pattern::NO_APPEND
                     name
                   else


### PR DESCRIPTION
標題のとおり

これまでコメントパターン30のとき、黄緑しか出力されていなかったのを、黄色も出すようにした

![image](https://github.com/yokenzan/receiptisan/assets/31175068/6bab4c58-dcd8-413f-9709-1186299f1f66)
