### PR TITLE
令和5年度点数表の期限を2024年5月に延長

### DIFF
--- a/lib/receiptisan/model/receipt_computer/master/versions.rb
+++ b/lib/receiptisan/model/receipt_computer/master/versions.rb
@@ -44,7 +44,7 @@ module Receiptisan
           V2019_R01 = new(2019, Month.new(2019, 4), Month.new(2020, 3))
           V2020_R02 = new(2020, Month.new(2020, 4), Month.new(2022, 3))
           V2022_R04 = new(2022, Month.new(2022, 4), Month.new(2023, 3))
-          V2023_R05 = new(2023, Month.new(2023, 4), Month.new(2024, 3))
+          V2023_R05 = new(2023, Month.new(2023, 4), Month.new(2024, 5))
         end
       end
     end

--- a/lib/receiptisan/util/formatter/kakkotsuki_formatter.rb
+++ b/lib/receiptisan/util/formatter/kakkotsuki_formatter.rb
@@ -7,7 +7,7 @@ module Receiptisan
         Formatter = ::Receiptisan::Util::Formatter
 
         KAKKO_ICHI_CODEPOINT = 0x2474 # ⑴のコードポイント
-        TARGET_RANGE         = 1..20
+        TARGET_RANGE         = (1..20).freeze
 
         # カッコ付数字の文字が含まれていたら置換する
         # @return [String]

--- a/spec/lib/receiptisan/model/receipt_computer/master/version_spec.rb
+++ b/spec/lib/receiptisan/model/receipt_computer/master/version_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Version do
 
     context '2023年度点数表期間の終点よりも未来の暦月の場合' do
       specify 'nilを返す' do
-        expect(described_class.resolve_by_ym(Month.new(2024, 4))).to be_nil
+        expect(described_class.resolve_by_ym(Month.new(2024, 6))).to be_nil
       end
     end
   end


### PR DESCRIPTION
標題のとおり